### PR TITLE
sdk: Change night/day mode transition behavior

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/display/ColorTemperatureController.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/display/ColorTemperatureController.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 The CyanogenMod Project
+ *               2018-2019 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +25,7 @@ import android.text.format.DateUtils;
 import android.util.MathUtils;
 import android.util.Range;
 import android.util.Slog;
-import android.view.animation.LinearInterpolator;
+import android.view.animation.AccelerateDecelerateInterpolator;
 
 import org.lineageos.platform.internal.display.TwilightTracker.TwilightState;
 
@@ -58,6 +59,7 @@ public class ColorTemperatureController extends LiveDisplayFeature {
     private int mDayTemperature;
     private int mNightTemperature;
 
+    private AccelerateDecelerateInterpolator mInterpolator;
     private ValueAnimator mAnimator;
 
     private final LineageHardwareManager mHardware;
@@ -97,6 +99,8 @@ public class ColorTemperatureController extends LiveDisplayFeature {
                 mColorTemperatureRange.getLower(),
                 mDefaultDayTemperature,
                 mColorTemperatureRange.getUpper());
+
+        mInterpolator = new AccelerateDecelerateInterpolator();
     }
 
     @Override
@@ -202,8 +206,8 @@ public class ColorTemperatureController extends LiveDisplayFeature {
         setDisplayTemperature(temperature);
 
         if (isTransitioning()) {
-            // fire again in a minute
-            mHandler.postDelayed(mTransitionRunnable, DateUtils.MINUTE_IN_MILLIS);
+            // fire again in 30 seconds
+            mHandler.postDelayed(mTransitionRunnable, DateUtils.MINUTE_IN_MILLIS / 2);
         }
     }
 
@@ -234,7 +238,7 @@ public class ColorTemperatureController extends LiveDisplayFeature {
 
         mAnimator = ValueAnimator.ofInt(current, balance);
         mAnimator.setDuration(duration);
-        mAnimator.setInterpolator(new LinearInterpolator());
+        mAnimator.setInterpolator(mInterpolator);
         mAnimator.addUpdateListener(new AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(final ValueAnimator animation) {
@@ -291,7 +295,7 @@ public class ColorTemperatureController extends LiveDisplayFeature {
      * @param sunrise
      * @return float between 0 and 1
      */
-    private static float adj(long now, long sunset, long sunrise) {
+    private float adj(long now, long sunset, long sunrise) {
         if (sunset < 0 || sunrise < 0
                 || now < (sunset - TWILIGHT_ADJUSTMENT_TIME)
                 || now > (sunrise + TWILIGHT_ADJUSTMENT_TIME)) {
@@ -301,12 +305,12 @@ public class ColorTemperatureController extends LiveDisplayFeature {
 
         // Scale the transition into night mode in 0.5hr before civil sunset
         if (now <= sunset) {
-            return (float) (sunset - now) / TWILIGHT_ADJUSTMENT_TIME;
+            return mInterpolator.getInterpolation((float) (sunset - now) / TWILIGHT_ADJUSTMENT_TIME);
         }
 
         // Scale the transition into day mode in 0.5hr after civil sunrise
         if (now >= sunrise) {
-            return (float) (now - sunrise) / TWILIGHT_ADJUSTMENT_TIME;
+            return mInterpolator.getInterpolation((float) (now - sunrise) / TWILIGHT_ADJUSTMENT_TIME);
         }
 
         // More than 0.5hr past civil sunset


### PR DESCRIPTION
* Update 2x a minute rather than 1x a minute as a result of dropping
  TWILIGHT_ADJUSTMENT_TIME from 1hr to 30min in an earlier change
* Use an AccelerateDecelerateInterpolator for transitioning from day
  to night mode and back to make the transition smoother for the user
* Update copyright while we're at it

Change-Id: I438f265c6cd9a2487b75744beccaf2bbac21b36e