### PR TITLE
sdk: Make phone a new compile target

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -80,7 +80,6 @@ lineage_sdk_LOCAL_STATIC_JAVA_LIBRARIES = [
 java_library {
     name: "org.lineageos.platform",
     static_libs: [
-        "libphonenumber",
         "telephony-ext"
     ] + lineage_sdk_LOCAL_STATIC_JAVA_LIBRARIES,
 
@@ -110,7 +109,6 @@ java_library_static {
     name: "org.lineageos.platform.internal",
     required: ["services"],
     static_libs: [
-        "libphonenumber",
         "telephony-ext"
     ] + lineage_sdk_LOCAL_STATIC_JAVA_LIBRARIES,
     libs: lineage_sdk_LOCAL_JAVA_LIBRARIES,

--- a/lib/Android.bp
+++ b/lib/Android.bp
@@ -1,0 +1,28 @@
+//
+// Copyright (C) 2019 The LineageOS Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+lineage_sdk_lib_src = "src/java/org/lineageos/lib/"
+
+java_library_static {
+    name: "org.lineageos.lib.phone",
+    static_libs: [
+        "libphonenumber",
+    ],
+
+    srcs: [
+        lineage_sdk_lib_src + "/phone/*.java",
+    ],
+}

--- a/lib/src/java/org/lineageos/lib/phone/SensitivePhoneNumber.java
+++ b/lib/src/java/org/lineageos/lib/phone/SensitivePhoneNumber.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.lineageos.internal.phone;
+package org.lineageos.lib.phone;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;

--- a/lib/src/java/org/lineageos/lib/phone/SensitivePhoneNumbers.java
+++ b/lib/src/java/org/lineageos/lib/phone/SensitivePhoneNumbers.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.lineageos.internal.phone;
+package org.lineageos.lib.phone;
 
 import android.content.Context;
 import android.os.Environment;


### PR DESCRIPTION
* Moving SensitivePhoneNumbers to sdk got us significantly bigger
  zip packages due to libphonenumber being part of every package that is
  using org.lineageos.platform or org.lineageos.platform.internal
* In order to correct this, move the "phone" folder to an own library that
  statically links libphonennumber and subsequentially make use of that
  package where needed

Change-Id: I4effd7a9248290aeb23ab47ff8e30385dce4401a